### PR TITLE
Add Python thumbnail generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,12 @@ _this is helpful for making meaningful thumbnails later, uses EXIF to unrotate)_
 
 Now, make thumbs for web purposes and eventual display of the images
 <https://gist.github.com/twobob/f5dd8a25195d730801df25bf048c3272>
-_(We chose 240x240 in the end, it scales nicely to 480, which is plenty for previews, not the 128x128 in the title)_  
+_(We chose 240x240 in the end, it scales nicely to 480, which is plenty for previews, not the 128x128 in the title)_
+
+`make_thumbs.py` automates this step using Python and Pillow. Run
+`python make_thumbs.py PATH_TO_IMAGES` to generate oriented thumbnails in a
+`thumbs` subfolder. A `thumbs/overlay/watermark.png` file can be used as an
+optional watermark.
 
 Since this is web facing we are all about size with thousands of files to serve,
 so we crunch the THUMB.JPG files in /thumbs with jpeg-recompress.exe

--- a/make_thumbs.py
+++ b/make_thumbs.py
@@ -1,0 +1,61 @@
+import argparse
+import os
+import platform
+from pathlib import Path
+from PIL import Image, ImageOps
+
+
+def process_images(folder: Path) -> None:
+    thumbs_dir = folder / "thumbs"
+    overlay_path = folder / "overlay" / "watermark.png"
+    thumbs_dir.mkdir(exist_ok=True)
+
+    existing_thumbs = {
+        p.name.replace(".THUMB.JPG", ".JPG") for p in thumbs_dir.glob("*.THUMB.JP*")
+    }
+
+    for img_path in sorted(folder.glob("*.JPG")):
+        if img_path.name in existing_thumbs:
+            continue
+
+        try:
+            image = Image.open(img_path)
+            image = ImageOps.exif_transpose(image)
+            thumb = image.resize((128, 128), Image.LANCZOS)
+
+            if overlay_path.exists():
+                logo = Image.open(overlay_path).convert("RGBA")
+                thumb.paste(logo, (0, 0), logo)
+
+            out_name = img_path.stem + ".THUMB.JPG"
+            thumb.convert("RGB").save(thumbs_dir / out_name, "JPEG")
+            print(f"Created {out_name}")
+        except Exception as e:
+            print(f"Failed to process {img_path}: {e}")
+
+
+def main() -> None:
+    default_pictures_folder = Path()
+    if platform.system() == "Windows":
+        default_pictures_folder = Path(os.environ["USERPROFILE"]) / "Pictures"
+        help_text_default_folder = "%USERPROFILE%\\Pictures"
+    else:
+        default_pictures_folder = Path.home() / "Pictures"
+        help_text_default_folder = "~/Pictures"
+
+    parser = argparse.ArgumentParser(
+        description="Create oriented thumbnails for JPG images"
+    )
+    parser.add_argument(
+        "folder",
+        nargs="?",
+        default=str(default_pictures_folder),
+        help=f"Folder containing images (default: {help_text_default_folder})",
+    )
+    args = parser.parse_args()
+
+    process_images(Path(args.folder))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `make_thumbs.py` for creating oriented thumbnails
- document usage in README

## Testing
- `python -m py_compile make_thumbs.py`


------
https://chatgpt.com/codex/tasks/task_e_684a261ea5a88330b3f1cc4ddb10d278