### PR TITLE
Remove verbose processed output

### DIFF
--- a/offline_tags.py
+++ b/offline_tags.py
@@ -67,7 +67,9 @@ def process_folder(folder_path_str: str):
                 }
                 all_questions_data.append(image_data_entry)
 
-                print(f"Processed {img_path.name}: found tags - {', '.join(tags_list)}")
+                # The progress bar already shows how many images were processed,
+                # so avoid printing per-image status messages that clutter the
+                # output.
                 pbar.update(1)
             except Exception as e:
                 print(f"Error processing {img_path.name}: {e}")


### PR DESCRIPTION
## Summary
- stop printing processed image tags from `offline_tags.py`

## Testing
- `python -m py_compile Ki/offline_tags.py Ki/run_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_684b40472d148330ac2724674ddaddb3