### PR TITLE
Add recursive image processing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ This project uses a local BLIP-2 captioning model to automatically tag your imag
 2.  **Process Your Images:**
     Navigate to the repository directory and run the main pipeline script, providing the path to your image folder:
     ```bash
-    python run_pipeline.py PATH_TO_YOUR_IMAGES
+    python run_pipeline.py PATH_TO_YOUR_IMAGES [--recurse]
     ```
     This script will:
-    *   Scan the `PATH_TO_YOUR_IMAGES` directory for JPG, JPEG, and PNG files.
+    *   Scan the `PATH_TO_YOUR_IMAGES` directory for JPG, JPEG, and PNG files. Use `--recurse` to include subfolders.
     *   Generate descriptive tags for each image using a local BLIP-2 model.
     *   Create thumbnails for each image and store them in the `img/thumbs/` directory. An optional watermark from `img/overlay/watermark.png` may be applied if `make_thumbs.py` (called by the pipeline) is configured for it.
     *   Compile all tag information into `data.json`, which is used by the search interface.

--- a/make_thumbs.py
+++ b/make_thumbs.py
@@ -7,7 +7,14 @@ import shutil
 from tqdm import tqdm
 
 
-def process_images(source_dir: Path, thumb_dir: Path, overlay_path: Path, thumb_size: int, clear_existing_thumbs: bool) -> None:
+def process_images(
+    source_dir: Path,
+    thumb_dir: Path,
+    overlay_path: Path,
+    thumb_size: int,
+    clear_existing_thumbs: bool,
+    recurse: bool = False,
+) -> None:
     script_dir = Path(__file__).resolve().parent # Get the directory of the currently running script
     # Use provided thumb_dir and overlay_path directly
 
@@ -32,10 +39,12 @@ def process_images(source_dir: Path, thumb_dir: Path, overlay_path: Path, thumb_
     }
 
     source_image_paths = []
-    # Define case-insensitive glob patterns for JPG, JPEG, and PNG files
     img_glob_patterns = ["*.[jJ][pP][gG]", "*.[jJ][pP][eE][gG]", "*.[pP][nN][gG]"]
     for pattern in img_glob_patterns:
-        source_image_paths.extend(source_dir.glob(pattern))
+        if recurse:
+            source_image_paths.extend(source_dir.rglob(pattern))
+        else:
+            source_image_paths.extend(source_dir.glob(pattern))
     
     total_source_images = len(source_image_paths)
     thumbnails_created_this_run = 0
@@ -220,6 +229,18 @@ if __name__ == "__main__":
         action="store_true",
         help="If set, clears all files from the thumbnail directory before generating new ones.",
     )
+    parser.add_argument(
+        "--recurse",
+        action="store_true",
+        help="Recurse into subdirectories when searching for images.",
+    )
     args = parser.parse_args()
 
-    process_images(args.source_dir, args.thumb_dir, args.overlay_path, args.thumb_size, args.clear_thumbs)
+    process_images(
+        args.source_dir,
+        args.thumb_dir,
+        args.overlay_path,
+        args.thumb_size,
+        args.clear_thumbs,
+        args.recurse,
+    )

--- a/offline_tags.py
+++ b/offline_tags.py
@@ -25,7 +25,13 @@ def extract_tags(caption, nlp):
     return sorted(tag.upper() for tag in nouns)
 
 
-def process_folder(folder_path_str: str):
+def process_folder(folder_path_str: str, recurse: bool = False):
+    """Process a folder of images and write captions/tags to data.json.
+
+    Args:
+        folder_path_str: Path to the folder of images.
+        recurse: If True, search folders recursively.
+    """
     # Determine the output path for data.json (in the script's directory)
     # Assuming the script is run from its location, __file__ should give its path.
     try:
@@ -47,8 +53,12 @@ def process_folder(folder_path_str: str):
 
     all_questions_data = []  # Initialize list to hold all image data
 
-    image_folder_path = Path(folder_path_str)  # Convert input string to Path
-    image_paths = [p for p in sorted(image_folder_path.iterdir()) if p.is_file() and p.suffix in img_extensions]
+    image_folder_path = Path(folder_path_str)
+    if recurse:
+        iter_paths = image_folder_path.rglob('*')
+    else:
+        iter_paths = image_folder_path.iterdir()
+    image_paths = [p for p in sorted(iter_paths) if p.is_file() and p.suffix in img_extensions]
 
     with tqdm(total=len(image_paths), desc="Captioning Images", unit="image") as pbar:
         for img_path in image_paths:
@@ -109,6 +119,11 @@ def main():
         default=str(default_pictures_folder),
         help=f"Folder containing images. Output will be written to data.json in the script's directory. (default: {help_text_default_folder})",
     )
+    parser.add_argument(
+        "--recurse",
+        action="store_true",
+        help="Recurse into subdirectories when scanning for images.",
+    )
     args = parser.parse_args()
 
     if not Path(args.folder).is_dir():
@@ -119,7 +134,7 @@ def main():
             )
         return
 
-    process_folder(args.folder)
+    process_folder(args.folder, args.recurse)
 
 
 if __name__ == "__main__":

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -57,6 +57,7 @@ def main():
     parser.add_argument('--watermark_path', type=str, default=os.path.join('img', 'overlay', 'watermark.png'), help='Path to the watermark image.')
     parser.add_argument('--clear_thumbs', action='store_true', help='Clear the thumbnails directory before generating new thumbnails.')
     parser.add_argument('--thumb_size', type=int, default=128, help='Size of the thumbnails (width and height).')
+    parser.add_argument('--recurse', action='store_true', help='Recurse into subdirectories when processing images.')
 
     args = parser.parse_args()
 
@@ -67,6 +68,7 @@ def main():
     thumbs_dir = args.thumbs_dir
     output_json = args.output_json
     watermark_path = args.watermark_path
+    recurse = args.recurse
 
     # Construct script paths relative to this script's location (project root)
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -81,6 +83,7 @@ def main():
     print(f"  Watermark Path: {watermark_path}")
     print(f"  Clear Thumbnails: {args.clear_thumbs}")
     print(f"  Thumbnail Size: {args.thumb_size}")
+    print(f"  Recurse into subfolders: {recurse}")
     print("-" * 30)
 
     # Prepare arguments for the individual steps
@@ -93,8 +96,12 @@ def main():
     ]
     if args.clear_thumbs:  # Correctly append --clear_thumbs only if True
         make_thumbs_args.append('--clear_thumbs')
+    if recurse:
+        make_thumbs_args.append('--recurse')
 
-    offline_tags_args = [originals_dir]  # Pass only the image source directory
+    offline_tags_args = [originals_dir]
+    if recurse:
+        offline_tags_args.append('--recurse')
 
     print("\nStep 1: Generating thumbnails...")
     if not run_script(make_thumbs_script, make_thumbs_args):


### PR DESCRIPTION
## Summary
- add `--recurse` flag throughout pipeline
- support recursion in `make_thumbs.py` and `offline_tags.py`
- pass new flag via `run_pipeline.py`
- document recursive option in README

## Testing
- `python run_pipeline.py -h`
- `python make_thumbs.py -h` *(fails: No module named 'PIL')*
- `python offline_tags.py -h` *(fails: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_684b5e4fc8c48330be8f617941cc93fb