### PR TITLE
Improve pipeline options and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@ This project uses a local BLIP-2 captioning model to automatically tag your imag
 2.  **Process Your Images:**
     Navigate to the repository directory and run the main pipeline script, providing the path to your image folder:
     ```bash
-    python run_pipeline.py PATH_TO_YOUR_IMAGES [--recurse]
+    python run_pipeline.py PATH_TO_YOUR_IMAGES [-R | --recurse] [-C | --clear]
     ```
+    **Windows users:** Avoid quoting a path that ends with a single backslash. Either remove the trailing backslash or escape it as `\\` so additional flags are parsed correctly.
     This script will:
-    *   Scan the `PATH_TO_YOUR_IMAGES` directory for JPG, JPEG, and PNG files. Use `--recurse` to include subfolders.
+    *   Scan the `PATH_TO_YOUR_IMAGES` directory for JPG, JPEG, and PNG files. Use `-R`/`--recurse` to include subfolders.
     *   Generate descriptive tags for each image using a local BLIP-2 model.
     *   Create thumbnails for each image and store them in the `img/thumbs/` directory. An optional watermark from `img/overlay/watermark.png` may be applied if `make_thumbs.py` (called by the pipeline) is configured for it.
+    *   Optionally clear the contents of `img/thumbs/` first when using `-C`/`--clear`.
     *   Compile all tag information into `data.json`, which is used by the search interface.
     *   Show per-image progress bars so you know exactly how many files remain.
 

--- a/make_thumbs.py
+++ b/make_thumbs.py
@@ -20,7 +20,7 @@ def process_images(
 
     if clear_existing_thumbs:
         if thumb_dir.exists():
-            print(f"--clear_thumbs specified. Clearing all items from {thumb_dir}...")
+            print(f"--clear specified. Clearing all items from {thumb_dir}...")
             for item in thumb_dir.iterdir():
                 if item.is_file():
                     item.unlink()
@@ -28,7 +28,7 @@ def process_images(
                     shutil.rmtree(item)
             print(f"Directory {thumb_dir} cleared.")
         else:
-            print(f"--clear_thumbs specified, but directory {thumb_dir} does not exist. Will create it.")
+            print(f"--clear specified, but directory {thumb_dir} does not exist. Will create it.")
     
     thumb_dir.mkdir(parents=True, exist_ok=True) # Ensure it exists, create parents if necessary
 
@@ -225,7 +225,8 @@ if __name__ == "__main__":
         help="Size of the thumbnails (width and height). Defaults to 128."
     )
     parser.add_argument(
-        "--clear_thumbs",
+        "-C",
+        "--clear",
         action="store_true",
         help="If set, clears all files from the thumbnail directory before generating new ones.",
     )
@@ -241,6 +242,6 @@ if __name__ == "__main__":
         args.thumb_dir,
         args.overlay_path,
         args.thumb_size,
-        args.clear_thumbs,
+        args.clear,
         args.recurse,
     )

--- a/offline_tags.py
+++ b/offline_tags.py
@@ -120,6 +120,7 @@ def main():
         help=f"Folder containing images. Output will be written to data.json in the script's directory. (default: {help_text_default_folder})",
     )
     parser.add_argument(
+        "-R",
         "--recurse",
         action="store_true",
         help="Recurse into subdirectories when scanning for images.",


### PR DESCRIPTION
## Summary
- rename `--clear_thumbs` to `--clear` and add short `-C`
- add `-R` short option for `--recurse`
- forward options in `run_pipeline.py`
- document new flags in README

## Testing
- `python -m py_compile run_pipeline.py make_thumbs.py offline_tags.py`
- `python run_pipeline.py -h`
- `python make_thumbs.py -h` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `python offline_tags.py -h` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_684b61c82c708330a9e582d069f95a72