### PR TITLE
Add verbose flag for pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This project uses a local BLIP-2 captioning model to automatically tag your imag
 2.  **Process Your Images:**
     Navigate to the repository directory and run the main pipeline script, providing the path to your image folder:
     ```bash
-    python run_pipeline.py PATH_TO_YOUR_IMAGES [-R | --recurse] [-C | --clear]
+    python run_pipeline.py PATH_TO_YOUR_IMAGES [-R | --recurse] [-C | --clear] [-V | --verbose]
     ```
     **Windows users:** Avoid quoting a path that ends with a single backslash. Either remove the trailing backslash or escape it as `\\` so additional flags are parsed correctly.
     This script will:
@@ -29,6 +29,7 @@ This project uses a local BLIP-2 captioning model to automatically tag your imag
     *   Optionally clear the contents of `img/thumbs/` first when using `-C`/`--clear`.
     *   Compile all tag information into `data.json`, which is used by the search interface.
     *   Show per-image progress bars so you know exactly how many files remain.
+    *   Use `-V`/`--verbose` to print per-image details instead of progress bars.
 
 3.  **Run the Web Server:**
     Once your images are processed and `data.json` is generated, start the local web server:

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -61,6 +61,8 @@ def main():
                         help='Size of the thumbnails (width and height).')
     parser.add_argument('-R', '--recurse', action='store_true',
                         help='Recurse into subdirectories when processing images.')
+    parser.add_argument('-V', '--verbose', action='store_true',
+                        help='Show per-image messages and disable progress bars in sub-scripts.')
 
     args = parser.parse_args()
 
@@ -101,6 +103,7 @@ def main():
     print(f"  Clear Thumbnails: {args.clear}")
     print(f"  Thumbnail Size: {args.thumb_size}")
     print(f"  Recurse into subfolders: {recurse}")
+    print(f"  Verbose output: {args.verbose}")
     print("-" * 30)
 
     # Prepare arguments for the individual steps
@@ -119,6 +122,9 @@ def main():
     offline_tags_args = [originals_dir]
     if recurse:
         offline_tags_args.append('--recurse')
+    if args.verbose:
+        make_thumbs_args.append('--verbose')
+        offline_tags_args.append('--verbose')
 
     print("\nStep 1: Generating thumbnails...")
     if not run_script(make_thumbs_script, make_thumbs_args):


### PR DESCRIPTION
## Summary
- add `-V`/`--verbose` flag to tools and docs
- show per-image progress only when verbose
- suppress thumbnail creation messages unless verbose

## Testing
- `python -m py_compile make_thumbs.py offline_tags.py run_pipeline.py`
- `python run_pipeline.py --help | head -n 20`
- `python offline_tags.py --help | head -n 20` *(fails: ModuleNotFoundError: No module named 'transformers')*
- `python make_thumbs.py --help | head -n 20` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684b680d17808330945e27b833da3d40