### PR TITLE
Add jpeglib thumbnail compression option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This project uses a local BLIP-2 captioning model to automatically tag your imag
 - [spaCy](https://spacy.io/) with the `en_core_web_sm` language model
 - [scikit-image](https://scikit-image.org/) for JPEG recompression metrics
 - `tqdm` for progress bars
+- Optional JPEG compression with `-J/--jpegli` uses the
+  [jpeglib](https://pypi.org/project/jpeglib/) Python package.
 
 Thumbnails are generated at **256×256** pixels by default, so ensure you have enough disk space for the resized copies.
 
@@ -22,7 +24,7 @@ Thumbnails are generated at **256×256** pixels by default, so ensure you have e
 1.  **Install Dependencies:**
     Ensure you have Python installed. Then, install the necessary libraries. While specific versions may vary, you'll typically need:
     ```bash
-    pip install Pillow scikit-image transformers torch torchvision torchaudio spacy tqdm
+    pip install Pillow scikit-image transformers torch torchvision torchaudio spacy tqdm jpeglib
     python -m spacy download en_core_web_sm 
     ```
     (Note: `torch` installation can vary based on your system and CUDA availability. Refer to the official PyTorch website for specific instructions if needed.)
@@ -30,7 +32,7 @@ Thumbnails are generated at **256×256** pixels by default, so ensure you have e
 2.  **Process Your Images:**
     Navigate to the repository directory and run the main pipeline script, providing the path to your image folder:
     ```bash
-    python run_pipeline.py [PATH_TO_YOUR_IMAGES] [-I PATH_TO_YOUR_IMAGES] [-O OUTPUT_DIR] [-R | --recurse] [-C | --clear] [-Z | --compress] [-V | --verbose]
+    python run_pipeline.py [PATH_TO_YOUR_IMAGES] [-I PATH_TO_YOUR_IMAGES] [-O OUTPUT_DIR] [-R | --recurse] [-C | --clear] [-Z | --compress] [-J | --jpegli] [-V | --verbose]
     ```
     **Windows users:** Avoid quoting a path that ends with a single backslash. Either remove the trailing backslash or escape it as `\\` so additional flags are parsed correctly.
 
@@ -39,7 +41,7 @@ Thumbnails are generated at **256×256** pixels by default, so ensure you have e
     *   Generate descriptive tags for each image using a local BLIP-2 model.
     *   Create **256×256** thumbnails for each image and store them in the output directory (default `img/thumbs/`). An optional watermark from `img/overlay/watermark.png` may be applied if `make_thumbs.py` (called by the pipeline) is configured for it.
     *   Optionally clear the contents of the output folder first when using `-C`/`--clear`.
-    *   Enable additional JPEG compression with `-Z`/`--compress`.
+    *   Enable additional JPEG compression with `-Z`/`--compress` or use the `jpeglib` library with `-J`/`--jpegli`. These options are mutually exclusive.
     *   Compile all tag information into `data.json`, which is used by the search interface.
     *   Show per-image progress bars so you know exactly how many files remain.
     *   Use `-V`/`--verbose` to print per-image details instead of progress bars.

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -106,6 +106,12 @@ def main():
         help="Enable jpeg-recompress for thumbnails.",
     )
     parser.add_argument(
+        "-J",
+        "--jpegli",
+        action="store_true",
+        help="Use jpeglib for thumbnail compression.",
+    )
+    parser.add_argument(
         "-R",
         "--recurse",
         action="store_true",
@@ -119,6 +125,9 @@ def main():
     )
 
     args = parser.parse_args()
+
+    if args.compress and args.jpegli:
+        parser.error("-Z/--compress and -J/--jpegli cannot be used together.")
 
     # Determine the raw input argument (from -I/--input or positional PATH)
     raw_input_arg = args.input if args.input else (args.input_path or str(default_originals_path))
@@ -137,6 +146,8 @@ def main():
                 args.clear = True
             elif flag in ("--compress", "-Z"):
                 args.compress = True
+            elif flag in ("--jpegli", "-J"):
+                args.jpegli = True
             else:
                 print(
                     f"Warning: Unrecognized token '{flag}' found in input path argument"
@@ -164,6 +175,7 @@ def main():
     print(f"  Watermark Path: {watermark_path}")
     print(f"  Clear Thumbnails: {args.clear}")
     print(f"  Compress Thumbnails: {args.compress}")
+    print(f"  Jpeglib Compression: {args.jpegli}")
     print(f"  Thumbnail Size: {args.thumb_size}")
     print(f"  Recurse into subfolders: {recurse}")
     print(f"  Verbose output: {args.verbose}")
@@ -185,6 +197,8 @@ def main():
         make_thumbs_args.append("--clear")
     if args.compress:
         make_thumbs_args.append("--compress")
+    if args.jpegli:
+        make_thumbs_args.append("--jpegli")
     if recurse:
         make_thumbs_args.append("--recurse")
 


### PR DESCRIPTION
## Summary
- remove bundled jpegli binary
- use `jpeglib` library when `-J/--jpegli` is specified
- keep `-Z` jpeg-recompress option mutually exclusive with `-J`
- document `jpeglib` dependency and usage

## Testing
- `python make_thumbs.py --source_dir img/test_src --thumb_dir img/thumbs_test --thumb_size 64 --clear -J`
- `python make_thumbs.py --source_dir img/test_src --thumb_dir img/thumbs_test --thumb_size 64 --clear -Z`
- `python make_thumbs.py --source_dir img/test_src --thumb_dir img/thumbs_test --thumb_size 64 --clear -Z -J` *(fails as expected)*
- `python run_pipeline.py img/test_src -O img/thumbs_test -C -J` *(fails at offline_tags due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_684b8e9a33e4833099fea834d4cc69ae