### PR TITLE
Improve pipeline reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Thumbnails are generated at **256×256** pixels by default, so ensure you have e
     This script will:
     *   Scan the `PATH_TO_YOUR_IMAGES` directory (positional or via `-I`/`--input`) for JPG, JPEG, and PNG files. Use `-R`/`--recurse` to include subfolders.
     *   Generate descriptive tags for each image using a local BLIP-2 model.
-    *   Create **256×256** thumbnails for each image and store them in the output directory (default `img/thumbs/`). An optional watermark from `img/overlay/watermark.png` may be applied if `make_thumbs.py` (called by the pipeline) is configured for it.
+    *   Create **256×256** thumbnails for each image and store them in the output directory (default `img/thumbs/`). An optional watermark from `img/overlay/watermark.png` may be applied if `make_thumbs.py` (called by the pipeline) is configured for it. Thumbnail file names now include the relative path to the source image so duplicates across folders or extensions won't overwrite each other.
     *   Optionally clear the contents of the output folder first when using `-C`/`--clear`.
     *   Enable additional JPEG compression with `-Z`/`--compress` or use the `jpeglib` library with `-J`/`--jpegli`. These options are mutually exclusive.
     *   Compile all tag information into `data.json`, which is used by the search interface.


### PR DESCRIPTION
## Summary
- use `use_fast=True` when loading the BLIP-2 processor
- generate unique thumbnail filenames based on relative paths
- keep track of already generated thumbs to avoid overwriting
- document the new naming behaviour in README

## Testing
- `python -m py_compile offline_tags.py make_thumbs.py run_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_684b96021f708330ab4cd2d94aeeb129