### PR TITLE
Support adding and deleting images with hashed thumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,20 @@ Thumbnails are generated at **256×256** pixels by default, so ensure you have e
 2.  **Process Your Images:**
     Navigate to the repository directory and run the main pipeline script, providing the path to your image folder:
     ```bash
-    python run_pipeline.py [PATH_TO_YOUR_IMAGES] [-I PATH_TO_YOUR_IMAGES] [-O OUTPUT_DIR] [-R | --recurse] [-C | --clear] [-Z | --compress] [-J | --jpegli] [-V | --verbose]
+    python run_pipeline.py [PATH_TO_YOUR_IMAGES] [-I PATH_TO_YOUR_IMAGES] [-O OUTPUT_DIR] [-R | --recurse] [-C | --clear] [-Z | --compress] [-J | --jpegli] [-A | --add] [-D | --delete] [-V | --verbose]
     ```
     **Windows users:** Avoid quoting a path that ends with a single backslash. Either remove the trailing backslash or escape it as `\\` so additional flags are parsed correctly.
 
     This script will:
     *   Scan the `PATH_TO_YOUR_IMAGES` directory (positional or via `-I`/`--input`) for JPG, JPEG, and PNG files. Use `-R`/`--recurse` to include subfolders.
     *   Generate descriptive tags for each image using a local BLIP-2 model.
-    *   Create **256×256** thumbnails for each image and store them in the output directory (default `img/thumbs/`). An optional watermark from `img/overlay/watermark.png` may be applied if `make_thumbs.py` (called by the pipeline) is configured for it. Thumbnail file names now include the relative path to the source image so duplicates across folders or extensions won't overwrite each other.
+    *   Create **256×256** thumbnails for each image and store them in the output directory (default `img/thumbs/`). An optional watermark from `img/overlay/watermark.png` may be applied if `make_thumbs.py` (called by the pipeline) is configured for it. Thumbnail file names now include a short hash of the original path so duplicates across folders or extensions will never collide.
     *   Optionally clear the contents of the output folder first when using `-C`/`--clear`.
     *   Enable additional JPEG compression with `-Z`/`--compress` or use the `jpeglib` library with `-J`/`--jpegli`. These options are mutually exclusive.
     *   Compile all tag information into `data.json`, which is used by the search interface.
     *   Show per-image progress bars so you know exactly how many files remain.
     *   Use `-V`/`--verbose` to print per-image details instead of progress bars.
+    *   Use `-A`/`--add` to append new images without rebuilding existing entries, or `-D`/`--delete` to remove records and thumbnails for images in the folder.
 
 3.  **Run the Web Server:**
     Once your images are processed and `data.json` is generated, start the local web server:

--- a/make_thumbs.py
+++ b/make_thumbs.py
@@ -6,6 +6,7 @@ from PIL import Image, ImageOps
 import tempfile
 import numpy as np
 import jpeglib
+import hashlib
 
 from jpeg_recompress import recompress
 import shutil
@@ -13,11 +14,13 @@ from tqdm import tqdm
 
 
 def generate_thumb_filename(img_path: Path, source_dir: Path) -> str:
-    """Generate a unique thumbnail filename based on the image's relative path."""
+    """Generate a thumbnail filename using the image path with a short hash."""
     relative = img_path.relative_to(source_dir)
     sanitized_parts = [part.replace(' ', '_').replace('.', '_') for part in relative.parts]
     sanitized = '_'.join(sanitized_parts)
-    return f"{sanitized}.THUMB.JPG"
+    # Include a short hash of the original relative path to avoid collisions
+    path_hash = hashlib.blake2s(str(relative).encode("utf-8"), digest_size=4).hexdigest()
+    return f"{sanitized}_{path_hash}.THUMB.JPG"
 
 
 def process_images(

--- a/offline_tags.py
+++ b/offline_tags.py
@@ -8,14 +8,17 @@ import os
 import platform
 import json  # Added import
 from tqdm import tqdm
+import hashlib
+from typing import Optional
 
 
 def generate_thumb_filename(img_path: Path, base_dir: Path) -> str:
-    """Create thumbnail filename matching make_thumbs.py."""
+    """Create thumbnail filename matching make_thumbs.py with hash."""
     relative = img_path.relative_to(base_dir)
     sanitized_parts = [part.replace(' ', '_').replace('.', '_') for part in relative.parts]
     sanitized = '_'.join(sanitized_parts)
-    return f"{sanitized}.THUMB.JPG"
+    path_hash = hashlib.blake2s(str(relative).encode("utf-8"), digest_size=4).hexdigest()
+    return f"{sanitized}_{path_hash}.THUMB.JPG"
 
 
 def caption_image(image_path, processor, model, device):  # device parameter might become redundant
@@ -33,20 +36,34 @@ def extract_tags(caption, nlp):
     return sorted(tag.upper() for tag in nouns)
 
 
-def process_folder(folder_path_str: str, recurse: bool = False, verbose: bool = False):
-    """Process a folder of images and write captions/tags to data.json.
+def process_folder(
+    folder_path_str: str,
+    recurse: bool = False,
+    verbose: bool = False,
+    add: bool = False,
+    delete: bool = False,
+    thumb_dir: Optional[Path] = None,
+    data_file: Optional[Path] = None,
+):
+    """Process a folder of images and update data.json.
 
     Args:
         folder_path_str: Path to the folder of images.
         recurse: If True, search folders recursively.
+        add: Append new entries to existing data.json instead of overwriting.
+        delete: Remove records (and thumbnails) for images in the folder.
+        thumb_dir: Location of thumbnails. Defaults to script_dir/img/thumbs.
+        data_file: Path to data.json. Defaults to script_dir/data.json.
     """
     # Determine the output path for data.json (in the script's directory)
     # Assuming the script is run from its location, __file__ should give its path.
     try:
         script_dir = Path(__file__).resolve().parent
-    except NameError:  # Fallback if __file__ is not defined (e.g. interactive execution)
+    except NameError:
         script_dir = Path.cwd()
-    output_json_path = script_dir / "data.json"
+
+    output_json_path = data_file if data_file else script_dir / "data.json"
+    thumb_directory = thumb_dir if thumb_dir else script_dir / "img" / "thumbs"
 
     # device variable might not be strictly needed if device_map works
     device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -66,8 +83,13 @@ def process_folder(folder_path_str: str, recurse: bool = False, verbose: bool = 
     nlp = spacy.load("en_core_web_sm")
     img_extensions = {".jpg", ".jpeg", ".png", ".JPG", ".JPEG", ".PNG"}
 
-    all_questions_data = []  # Initialize list to hold all image data
+    existing_data = []
+    if add or delete:
+        if output_json_path.exists():
+            with open(output_json_path, "r", encoding="utf-8") as f_existing:
+                existing_data = json.load(f_existing).get("questions", [])
 
+    all_questions_data = []  # Initialize list to hold all image data
     image_folder_path = Path(folder_path_str)
     if recurse:
         iter_paths = image_folder_path.rglob('*')
@@ -75,8 +97,26 @@ def process_folder(folder_path_str: str, recurse: bool = False, verbose: bool = 
         iter_paths = image_folder_path.iterdir()
     image_paths = [p for p in sorted(iter_paths) if p.is_file() and p.suffix in img_extensions]
 
+    # Handle deletion before any captioning work
+    if delete:
+        names_to_delete = {p.name for p in image_paths}
+        remaining = [e for e in existing_data if e.get("img", {}).get("filename") not in names_to_delete]
+        for img_path in image_paths:
+            thumb_name = generate_thumb_filename(img_path, image_folder_path)
+            thumb_path = thumb_directory / thumb_name
+            if thumb_path.exists():
+                thumb_path.unlink()
+        with open(output_json_path, "w", encoding="utf-8") as f_json:
+            json.dump({"questions": remaining}, f_json, indent=4)
+        print(f"Updated {output_json_path}")
+        return
+
+    existing_names = {e.get("img", {}).get("filename") for e in existing_data}
+
     if verbose:
         for img_path in image_paths:
+            if add and img_path.name in existing_names:
+                continue
             try:
                 caption = caption_image(img_path, processor, model, device)
                 tags_list = extract_tags(caption, nlp)
@@ -93,35 +133,34 @@ def process_folder(folder_path_str: str, recurse: bool = False, verbose: bool = 
                 print(f"Tags for {img_path.name}: {', '.join(tags_list)}")
             except Exception as e:
                 print(f"Error processing {img_path.name}: {e}")
-            # Removed writing to individual .txt files
     else:
         with tqdm(total=len(image_paths), desc="Captioning Images", unit="image") as pbar:
             for img_path in image_paths:
+                if add and img_path.name in existing_names:
+                    pbar.update(1)
+                    continue
                 try:
                     caption = caption_image(img_path, processor, model, device)
-                    tags_list = extract_tags(caption, nlp)  # Get list of tags
+                    tags_list = extract_tags(caption, nlp)
 
-                    # Create the desired dictionary format for content
                     content_dict = {tag: "1.0" for tag in tags_list}
 
                     thumb_filename = generate_thumb_filename(img_path, image_folder_path)
                     image_data_entry = {
                         "img": {"filename": img_path.name},
-                        "question": {"content": content_dict},  # Changed "tags" to "content" and used the new dict
+                        "question": {"content": content_dict},
                         "thumb": {"filename": thumb_filename},
                     }
                     all_questions_data.append(image_data_entry)
-
-                    # The progress bar already shows how many images were processed,
-                    # so avoid printing per-image status messages that clutter the
-                    # output.
                     pbar.update(1)
                 except Exception as e:
                     print(f"Error processing {img_path.name}: {e}")
                     pbar.update(1)
-                # Removed writing to individual .txt files
 
-    final_output_data = {"questions": all_questions_data}
+    if add:
+        final_output_data = {"questions": existing_data + all_questions_data}
+    else:
+        final_output_data = {"questions": all_questions_data}
 
     with open(output_json_path, "w", encoding="utf-8") as f_json:
         json.dump(final_output_data, f_json, indent=4)
@@ -166,7 +205,32 @@ def main():
         action="store_true",
         help="Show per-image tags and disable progress bars.",
     )
+    parser.add_argument(
+        "-A",
+        "--add",
+        action="store_true",
+        help="Add images to existing data.json instead of overwriting.",
+    )
+    parser.add_argument(
+        "-D",
+        "--delete",
+        action="store_true",
+        help="Delete records and thumbnails for images in the folder.",
+    )
+    parser.add_argument(
+        "--thumb_dir",
+        type=Path,
+        help="Thumbnail directory. Defaults to script_dir/img/thumbs.",
+    )
+    parser.add_argument(
+        "--data_file",
+        type=Path,
+        help="Path to data.json. Defaults to script_dir/data.json.",
+    )
     args = parser.parse_args()
+
+    if args.add and args.delete:
+        parser.error("--add and --delete cannot be used together")
 
     if not Path(args.folder).is_dir():
         print(f"Error: Folder does not exist: {args.folder}")
@@ -176,7 +240,15 @@ def main():
             )
         return
 
-    process_folder(args.folder, args.recurse, args.verbose)
+    process_folder(
+        args.folder,
+        args.recurse,
+        args.verbose,
+        add=args.add,
+        delete=args.delete,
+        thumb_dir=args.thumb_dir,
+        data_file=args.data_file,
+    )
 
 
 if __name__ == "__main__":

--- a/offline_tags.py
+++ b/offline_tags.py
@@ -116,6 +116,8 @@ def process_folder(
     if verbose:
         for img_path in image_paths:
             if add and img_path.name in existing_names:
+                if verbose:
+                    print(f"Skipping {img_path.name} as it already exists in the dataset.")
                 continue
             try:
                 caption = caption_image(img_path, processor, model, device)


### PR DESCRIPTION
## Summary
- append short hashes to thumbnail filenames to avoid collisions
- implement `--add`/`--delete` options in `offline_tags.py`
- make pipeline pass through new options
- document new flags and hashed thumbnails

## Testing
- `python -m py_compile make_thumbs.py offline_tags.py run_pipeline.py serve.py`

------
https://chatgpt.com/codex/tasks/task_e_684ba8470d948330a66b00eeda6aac49