### PR TITLE
Fix consistent folder hashes and CLI message

### DIFF
--- a/make_thumbs.py
+++ b/make_thumbs.py
@@ -6,7 +6,7 @@ from PIL import Image, ImageOps
 import tempfile
 import numpy as np
 import jpeglib
-import hashlib
+from thumb_utils import folder_hash
 
 from jpeg_recompress import recompress
 import shutil
@@ -18,8 +18,8 @@ def generate_thumb_filename(img_path: Path, source_dir: Path) -> str:
     relative = img_path.relative_to(source_dir)
     sanitized_parts = [part.replace(' ', '_').replace('.', '_') for part in relative.parts]
     sanitized = '_'.join(sanitized_parts)
-    # Include a short hash of the original relative path to avoid collisions
-    path_hash = hashlib.blake2s(str(relative).encode("utf-8"), digest_size=4).hexdigest()
+    # Include a short hash of the directory path to avoid collisions
+    path_hash = folder_hash(relative.parent)
     return f"{sanitized}_{path_hash}.THUMB.JPG"
 
 

--- a/offline_tags.py
+++ b/offline_tags.py
@@ -8,8 +8,8 @@ import os
 import platform
 import json  # Added import
 from tqdm import tqdm
-import hashlib
 from typing import Optional
+from thumb_utils import folder_hash
 
 
 def generate_thumb_filename(img_path: Path, base_dir: Path) -> str:
@@ -17,7 +17,7 @@ def generate_thumb_filename(img_path: Path, base_dir: Path) -> str:
     relative = img_path.relative_to(base_dir)
     sanitized_parts = [part.replace(' ', '_').replace('.', '_') for part in relative.parts]
     sanitized = '_'.join(sanitized_parts)
-    path_hash = hashlib.blake2s(str(relative).encode("utf-8"), digest_size=4).hexdigest()
+    path_hash = folder_hash(relative.parent)
     return f"{sanitized}_{path_hash}.THUMB.JPG"
 
 
@@ -232,7 +232,7 @@ def main():
     args = parser.parse_args()
 
     if args.add and args.delete:
-        parser.error("--add and --delete cannot be used together")
+        parser.error("-A/--add and -D/--delete cannot be used together")
 
     if not Path(args.folder).is_dir():
         print(f"Error: Folder does not exist: {args.folder}")

--- a/thumb_utils.py
+++ b/thumb_utils.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+import hashlib
+
+
+def folder_hash(path: Path) -> str:
+    """Return a short, deterministic hash for the given directory path."""
+    return hashlib.blake2s(str(path).encode("utf-8"), digest_size=4).hexdigest()


### PR DESCRIPTION
## Summary
- ensure thumbnail hashes are based on parent directory path
- centralize folder hashing in `thumb_utils` module
- include short flags in --add/--delete conflict error

## Testing
- `python -m py_compile offline_tags.py make_thumbs.py thumb_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_684c1d8a5c348330bc48b3e41dc22253