### PR TITLE
Add -S flag to pipeline for optional server start

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Thumbnails are generated at **256×256** pixels by default, so ensure you have e
 2.  **Process Your Images:**
     Navigate to the repository directory and run the main pipeline script, providing the path to your image folder:
     ```bash
-    python run_pipeline.py [PATH_TO_YOUR_IMAGES] [-I PATH_TO_YOUR_IMAGES] [-O OUTPUT_DIR] [-R | --recurse] [-C | --clear] [-Z | --compress] [-J | --jpegli] [-A | --add] [-D | --delete] [-V | --verbose]
+    python run_pipeline.py [PATH_TO_YOUR_IMAGES] [-I PATH_TO_YOUR_IMAGES] [-O OUTPUT_DIR] [-R | --recurse] [-C | --clear] [-Z | --compress] [-J | --jpegli] [-A | --add] [-D | --delete] [-V | --verbose] [-S [PORT]]
     ```
     **Windows users:** Avoid quoting a path that ends with a single backslash. Either remove the trailing backslash or escape it as `\\` so additional flags are parsed correctly.
 
@@ -46,9 +46,10 @@ Thumbnails are generated at **256×256** pixels by default, so ensure you have e
     *   Show per-image progress bars so you know exactly how many files remain.
     *   Use `-V`/`--verbose` to print per-image details instead of progress bars.
     *   Use `-A`/`--add` to append new images without rebuilding existing entries, or `-D`/`--delete` to remove records and thumbnails for images in the folder.
+    *   Use `-S [PORT]` to automatically launch the local server after processing. Omit `PORT` to use `serve.py`'s default.
 
 3.  **Run the Web Server:**
-    Once your images are processed and `data.json` is generated, start the local web server:
+    If you didn't use `-S` during the pipeline step, start the local web server manually:
     ```bash
     python serve.py
     ```

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -140,6 +140,17 @@ def main():
         action="store_true",
         help="Delete records and thumbnails for images in the folder.",
     )
+    parser.add_argument(
+        "-S",
+        "--serve",
+        nargs="?",
+        const="",
+        metavar="PORT",
+        help=(
+            "Start serve.py after the pipeline finishes. Optionally provide a PORT; "
+            "if omitted, serve.py's default port is used."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -187,6 +198,7 @@ def main():
     script_dir = os.path.dirname(os.path.abspath(__file__))
     make_thumbs_script = os.path.join(script_dir, "make_thumbs.py")
     offline_tags_script = os.path.join(script_dir, "offline_tags.py")
+    serve_script = os.path.join(script_dir, "serve.py")
     # build_data_json_script = os.path.join(script_dir, 'build_data_json.py') # Removed
 
     print(f"Pipeline Configuration:")
@@ -257,6 +269,14 @@ def main():
     #     return
 
     print("\nPipeline completed successfully!")
+
+    if args.serve is not None:
+        print("\nLaunching local server...")
+        serve_args = []
+        if args.serve:
+            serve_args.append(args.serve)
+        if not run_script(serve_script, serve_args):
+            print("Failed to start server.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `-S/--serve` flag to `run_pipeline.py` to optionally launch `serve.py`
- document the new flag and its usage in README

## Testing
- `python -m py_compile run_pipeline.py serve.py offline_tags.py make_thumbs.py`
- `python run_pipeline.py -h`

------
https://chatgpt.com/codex/tasks/task_e_684ce817f7ac8330910efbde0a74a428