### PR TITLE
Improve cross-platform user folder paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Thumbnails are generated at **256×256** pixels by default, so ensure you have e
 
 2.  **Process Your Images:**
     Navigate to the repository directory and run the main pipeline script, providing the path to your image folder:
+    Typical locations are `%USERPROFILE%\Pictures` on Windows or `~/Pictures` on Linux/macOS.
     ```bash
     python run_pipeline.py [PATH_TO_YOUR_IMAGES] [-I PATH_TO_YOUR_IMAGES] [-O OUTPUT_DIR] [-R | --recurse] [-C | --clear] [-Z | --compress] [-J | --jpegli] [-A | --add] [-D | --delete] [-V | --verbose] [-S [PORT]]
     ```

--- a/make_thumbs.py
+++ b/make_thumbs.py
@@ -293,11 +293,19 @@ if __name__ == "__main__":
     )
     script_dir = Path(__file__).resolve().parent
 
+    default_pictures_folder = get_default_pictures_folder()
+    if platform.system() == "Windows":
+        help_text_default_folder = "%USERPROFILE%\\Pictures"
+    else:
+        help_text_default_folder = "~/Pictures"
     parser.add_argument(
         "--source_dir",
         type=Path,
-        default=get_default_pictures_folder(),
-        help=f"Directory containing the original images. Defaults to your OS's default pictures folder ({get_default_pictures_folder()}).",
+        default=default_pictures_folder,
+        help=(
+            "Directory containing the original images. "
+            f"Defaults to your OS's default pictures folder ({help_text_default_folder})."
+        ),
     )
     parser.add_argument(
         "--thumb_dir",

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -53,10 +53,17 @@ def main():
 
     # Use the helper function for the default value
     default_originals_path = get_default_pictures_folder()
+    if platform.system() == "Windows":
+        help_text_default_folder = "%USERPROFILE%\\Pictures"
+    else:
+        help_text_default_folder = "~/Pictures"
     parser.add_argument(
         "input_path",
         nargs="?",
-        help=f"Directory containing original images. Defaults to OS pictures folder: {default_originals_path}",
+        help=(
+            "Directory containing original images. "
+            f"Defaults to OS pictures folder: {help_text_default_folder}"
+        ),
     )
 
     parser.add_argument(
@@ -161,8 +168,10 @@ def main():
     raw_input_arg = args.input if args.input else (args.input_path or str(default_originals_path))
 
     # Fix common Windows quoting mistakes where extra flags become part of the
-    # input path argument (e.g. `"C:\Users\me\Pictures\" -R -C`).
-    # This happens when a trailing backslash escapes the closing quote.
+    # input path argument (e.g. `%USERPROFILE%\Pictures` -R -C). On Linux/macOS
+    # the equivalent would be `~/Pictures`.
+    # This happens when a trailing backslash escapes the closing quote on
+    # Windows.
     # If such a situation is detected, split the argument and recover the flags.
     parts = raw_input_arg.split()
     if len(parts) > 1 and any(p.startswith("-") for p in parts[1:]):


### PR DESCRIPTION
## Summary
- document typical user image folder paths in README
- show `%USERPROFILE%\Pictures` or `~/Pictures` in make_thumbs.py help
- show `%USERPROFILE%\Pictures` or `~/Pictures` in run_pipeline.py help and comments

## Testing
- `python -m py_compile run_pipeline.py make_thumbs.py offline_tags.py`

------
https://chatgpt.com/codex/tasks/task_e_684ceb331e608330b52491a5ada7a2af