### PR TITLE
Fix path hashing logic for consistent thumbnails

### DIFF
--- a/make_thumbs.py
+++ b/make_thumbs.py
@@ -13,13 +13,13 @@ import shutil
 from tqdm import tqdm
 
 
-def generate_thumb_filename(img_path: Path, source_dir: Path) -> str:
-    """Generate a thumbnail filename using the image path with a short hash."""
-    relative = img_path.relative_to(source_dir)
+def generate_thumb_filename(img_path: Path) -> str:
+    """Generate a thumbnail filename using the full image path with a short hash."""
+    absolute = img_path.resolve()
+    relative = absolute.relative_to(absolute.anchor)
     sanitized_parts = [part.replace(' ', '_').replace('.', '_') for part in relative.parts]
     sanitized = '_'.join(sanitized_parts)
-    # Include a short hash of the directory path to avoid collisions
-    path_hash = folder_hash(relative.parent)
+    path_hash = folder_hash(absolute.parent)
     return f"{sanitized}_{path_hash}.THUMB.JPG"
 
 
@@ -93,7 +93,7 @@ def process_images(
         pbar = tqdm(total=total_source_images, desc="Creating Thumbnails", unit="image")
 
     for img_path in iterator:
-        thumb_filename = generate_thumb_filename(img_path, source_dir)
+        thumb_filename = generate_thumb_filename(img_path)
         thumb_save_path = thumb_dir / thumb_filename
 
         # Skip processing if this thumbnail already exists

--- a/offline_tags.py
+++ b/offline_tags.py
@@ -12,12 +12,13 @@ from typing import Optional
 from thumb_utils import folder_hash
 
 
-def generate_thumb_filename(img_path: Path, base_dir: Path) -> str:
+def generate_thumb_filename(img_path: Path) -> str:
     """Create thumbnail filename matching make_thumbs.py with hash."""
-    relative = img_path.relative_to(base_dir)
+    absolute = img_path.resolve()
+    relative = absolute.relative_to(absolute.anchor)
     sanitized_parts = [part.replace(' ', '_').replace('.', '_') for part in relative.parts]
     sanitized = '_'.join(sanitized_parts)
-    path_hash = folder_hash(relative.parent)
+    path_hash = folder_hash(absolute.parent)
     return f"{sanitized}_{path_hash}.THUMB.JPG"
 
 
@@ -106,7 +107,7 @@ def process_folder(
             if e.get("img", {}).get("filename") not in names_to_delete
         ]
         for img_path in image_paths:
-            thumb_name = generate_thumb_filename(img_path, image_folder_path)
+            thumb_name = generate_thumb_filename(img_path)
             thumb_path = thumb_directory / thumb_name
             if thumb_path.exists():
                 thumb_path.unlink()
@@ -134,7 +135,7 @@ def process_folder(
                 tags_list = extract_tags(caption, nlp)
 
                 content_dict = {tag: "1.0" for tag in tags_list}
-                thumb_filename = generate_thumb_filename(img_path, image_folder_path)
+                thumb_filename = generate_thumb_filename(img_path)
                 image_data_entry = {
                     "img": {"filename": img_path.name},
                     "question": {"content": content_dict},
@@ -157,7 +158,7 @@ def process_folder(
 
                     content_dict = {tag: "1.0" for tag in tags_list}
 
-                    thumb_filename = generate_thumb_filename(img_path, image_folder_path)
+                    thumb_filename = generate_thumb_filename(img_path)
                     image_data_entry = {
                         "img": {"filename": img_path.name},
                         "question": {"content": content_dict},

--- a/thumb_utils.py
+++ b/thumb_utils.py
@@ -4,4 +4,4 @@ import hashlib
 
 def folder_hash(path: Path) -> str:
     """Return a short, deterministic hash for the given directory path."""
-    return hashlib.blake2s(str(path).encode("utf-8"), digest_size=4).hexdigest()
+    return hashlib.blake2s(str(path.resolve()).encode("utf-8"), digest_size=4).hexdigest()


### PR DESCRIPTION
## Summary
- compute folder hash using absolute path
- generate thumbnail filenames based on full absolute path

## Testing
- `pip install Pillow`
- `pip install numpy`
- `pip install scikit-image`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850ac440fd08330b4d257a0a74fecf1