### PR TITLE
Fix autocomplete overlay stacking order

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -149,6 +149,7 @@ pre .comment {
 
 #autocomplete-container {
   position: relative;
+  z-index: 2000;
 }
 
 .autocomplete-items {
@@ -160,7 +161,7 @@ pre .comment {
   background: white;
   max-height: 150px;
   overflow-y: auto;
-  z-index: 1000;
+  z-index: 2001;
   padding: 0;
   margin: 0;
   list-style: none;


### PR DESCRIPTION
## Summary
- fix z-index on autocomplete container and list so dropdown shows above surrounding divs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851e151b5948330a0a1f05a34511cde