### PR TITLE
Fix search dropdown stacking

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -176,3 +176,11 @@ pre .comment {
 .autocomplete-items li:hover {
   background-color: #eee;
 }
+
+#search-container {
+  z-index: 3000;
+}
+
+#question-view-container {
+  z-index: 1000;
+}

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 
                 <div class="row" style="margin-left: 0px; margin-right: 0px;">
                     <div class="col-md-6" style="margin-left: 0px; margin-right: 0px; width: 520px;">
-<div class="fixed" style="margin-left: 0px; margin-right: 0px; position: fixed; width: 480px;">
+<div id="search-container" class="fixed" style="margin-left: 0px; margin-right: 0px; position: fixed; width: 480px;">
 <form>
                             <div class="form-group has-success">
                                 <div class="col-xs-9" style="padding-left: 0px;">


### PR DESCRIPTION
## Summary
- assign `search-container` id to the search bar wrapper
- adjust CSS stacking order so autocomplete results display over images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e3b4b8a883308859994b93ba5b25